### PR TITLE
Fix: Prevent Event Loop blocking and Exit Code 255 during database save

### DIFF
--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -311,7 +311,7 @@ class CacheManager extends EventEmitter {
             logger.log(this._sk(), 'Channels in cache:', data.channels.length, ', genres:', data.genres.length, ', cache rebuilt');
 
             // Salva nel database
-            this.saveCacheToDB();
+            await this.saveCacheToDB();
 
             this.emit('cacheUpdated', this.cache);
 

--- a/src/cache-manager.js
+++ b/src/cache-manager.js
@@ -73,16 +73,17 @@ class CacheManager extends EventEmitter {
         }
     }
 
-    saveDatabase() {
+   // Rendi la funzione asincrona
+    async saveDatabase() {
         try {
             const data = this.db.export();
             const buffer = Buffer.from(data);
-            fs.writeFileSync(this.dbPath, buffer);
+            // Usa writeFile invece di writeFileSync
+            await fs.promises.writeFile(this.dbPath, buffer); 
         } catch (error) {
             logger.error(this._sk(), 'Cache database save error:', error);
         }
     }
-
     loadCacheFromDB() {
         try {
             // Carica metadata
@@ -135,7 +136,7 @@ class CacheManager extends EventEmitter {
         }
     }
 
-    saveCacheToDB() {
+   async saveCacheToDB() {
         try {
             // Salva metadata
             if (this.cache.lastUpdated) {
@@ -176,7 +177,7 @@ class CacheManager extends EventEmitter {
                 stmt.free();
             }
 
-            this.saveDatabase();
+            await this.saveDatabase();
             logger.log(this._sk(), 'Cache saved to database');
         } catch (error) {
             logger.error(this._sk(), 'Cache save to database error:', error);


### PR DESCRIPTION
### Description
This PR fixes an issue where the application crashes with `Exit Code 255` on instances with limited resources (e.g., free tiers on Koyeb, Heroku, Raspberry Pi) immediately after saving the cache to the database.

### The Problem
In `cache-manager.js`, the `saveDatabase()` function uses `this.db.export()` and `fs.writeFileSync()`. When handling playlists, duplicating the in-memory database to a Buffer and synchronously writing it to the disk blocks the Node.js Event Loop. On containerized environments with limited RAM or slow I/O, this synchronous block causes health checks to fail or triggers a silent Out-Of-Memory (OOM) kill, resulting in a sudden crash.

### The Solution
* Converted `saveDatabase()` to an `async` function and replaced `fs.writeFileSync` with `fs.promises.writeFile` to allow non-blocking I/O.
* Converted `saveCacheToDB()` to an `async` function to properly `await` the database save.
* Added the missing `await` to `this.saveCacheToDB()` inside the `rebuildCache()` function.

These changes ensure the event loop is not blocked during large file writes, improving the overall stability of the addon without changing its core behavior.